### PR TITLE
Залить изменения из другого мерж реквеста пока автор молчит

### DIFF
--- a/EntityFrameworkCore.UseRowNumberForPaging/Offset2RowNumberConvertVisitor.net8.cs
+++ b/EntityFrameworkCore.UseRowNumberForPaging/Offset2RowNumberConvertVisitor.net8.cs
@@ -19,7 +19,7 @@ internal class Offset2RowNumberConvertVisitor : ExpressionVisitor
         var method = typeof(SelectExpression).GetMethod("GenerateOuterColumn", BindingFlags.NonPublic | BindingFlags.Instance);
         if (!typeof(ColumnExpression).IsAssignableFrom(method?.ReturnType))
         {
-            throw new InvalidOperationException("SelectExpression.GenerateOuterColum() was not found");
+            throw new InvalidOperationException("SelectExpression.GenerateOuterColumn() was not found");
         }
 
         TableReferenceExpressionType = method.GetParameters().First().ParameterType;
@@ -43,7 +43,7 @@ internal class Offset2RowNumberConvertVisitor : ExpressionVisitor
         }
         if (node is SelectExpression se)
         {
-            return VisitSelect(se);
+            node = VisitSelect(se);
         }
         return base.VisitExtension(node);
     }


### PR DESCRIPTION
[Instead of attempting to get away without using reflection (and then resorting to it anyways), this setup reuses the previously used approach to updating the SelectExpression. Due to internal changes that means a slightly different invocation of the GenerateOuterColumnAccessor preceded by a reflection-based restoration of the _sqlAliasManager that is needed for the call of PushDownIntoSubQuery. Future versions of .NET may make this obsolete by removing the use of SqlAliasManager within SelectExpression entirely, but that's a future concern.](https://github.com/Rwing/EntityFrameworkCore.UseRowNumberForPaging/pull/18)